### PR TITLE
drivers/generic_modbus.c: adapt to two libmodbus timeout APIs

### DIFF
--- a/drivers/generic_modbus.c
+++ b/drivers/generic_modbus.c
@@ -26,7 +26,7 @@
 #include <timehead.h>
 
 #define DRIVER_NAME "NUT Generic Modbus driver"
-#define DRIVER_VERSION  "0.01"
+#define DRIVER_VERSION  "0.02"
 
 /* variables */
 static modbus_t *mbctx = NULL;                             /* modbus memory context */

--- a/drivers/generic_modbus.c
+++ b/drivers/generic_modbus.c
@@ -128,18 +128,47 @@ void upsdrv_initups(void)
     }
 
     /* set modbus response timeout */
+#if (defined NUT_MODBUS_TIMEOUT_ARG_sec_usec_uint32) || (defined NUT_MODBUS_TIMEOUT_ARG_sec_usec_uint32_cast_timeval_fields)
     rval = modbus_set_response_timeout(mbctx, mod_resp_to_s, mod_resp_to_us);
     if (rval < 0) {
         modbus_free(mbctx);
         fatalx(EXIT_FAILURE, "modbus_set_response_timeout: error(%s)", modbus_strerror(errno));
     }
+#elif (defined NUT_MODBUS_TIMEOUT_ARG_timeval_numeric_fields)
+    {
+        /* Older libmodbus API (with timeval), and we have
+         * checked at configure time that we can put uint32_t
+         * into its fields. They are probably "long" on many
+         * systems as respectively time_t and suseconds_t -
+         * but that is not guaranteed; for more details see
+         * https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_time.h.html
+         */
+        struct timeval to = (struct timeval){0};
+        to.tv_sec = mod_resp_to_s;
+        to.tv_usec = mod_resp_to_us;
+        /* void */ modbus_set_response_timeout(mbctx, &to);
+    }
+/* #elif (defined NUT_MODBUS_TIMEOUT_ARG_timeval) // some un-castable type in fields */
+#else
+# error "Can not use libmodbus API for timeouts"
+#endif /* NUT_MODBUS_TIMEOUT_ARG_* */
 
     /* set modbus byte time out */
+#if (defined NUT_MODBUS_TIMEOUT_ARG_sec_usec_uint32) || (defined NUT_MODBUS_TIMEOUT_ARG_sec_usec_uint32_cast_timeval_fields)
     rval = modbus_set_byte_timeout(mbctx, mod_byte_to_s, mod_byte_to_us);
     if (rval < 0) {
         modbus_free(mbctx);
         fatalx(EXIT_FAILURE, "modbus_set_byte_timeout: error(%s)", modbus_strerror(errno));
     }
+#elif (defined NUT_MODBUS_TIMEOUT_ARG_timeval_numeric_fields)
+    {   /* see comments above */
+        struct timeval to = (struct timeval){0};
+        to.tv_sec = mod_byte_to_s;
+        to.tv_usec = mod_byte_to_us;
+        /* void */ modbus_set_byte_timeout(mbctx, &to);
+    }
+/* #elif (defined NUT_MODBUS_TIMEOUT_ARG_timeval) // some un-castable type in fields */
+#endif /* NUT_MODBUS_TIMEOUT_ARG_* */
 }
 
 /* update UPS signal state */
@@ -1017,16 +1046,36 @@ void modbus_reconnect()
     }
 
     /* set modbus response timeout */
+#if (defined NUT_MODBUS_TIMEOUT_ARG_sec_usec_uint32) || (defined NUT_MODBUS_TIMEOUT_ARG_sec_usec_uint32_cast_timeval_fields)
     rval = modbus_set_response_timeout(mbctx, mod_resp_to_s, mod_resp_to_us);
     if (rval < 0) {
         modbus_free(mbctx);
         fatalx(EXIT_FAILURE, "modbus_set_response_timeout: error(%s)", modbus_strerror(errno));
     }
+#elif (defined NUT_MODBUS_TIMEOUT_ARG_timeval_numeric_fields)
+    {   /* see comments above */
+        struct timeval to = (struct timeval){0};
+        to.tv_sec = mod_resp_to_s;
+        to.tv_usec = mod_resp_to_us;
+        /* void */ modbus_set_response_timeout(mbctx, &to);
+    }
+/* #elif (defined NUT_MODBUS_TIMEOUT_ARG_timeval) // some un-castable type in fields */
+#endif /* NUT_MODBUS_TIMEOUT_ARG_* */
 
     /* set modbus byte timeout */
+#if (defined NUT_MODBUS_TIMEOUT_ARG_sec_usec_uint32) || (defined NUT_MODBUS_TIMEOUT_ARG_sec_usec_uint32_cast_timeval_fields)
     rval = modbus_set_byte_timeout(mbctx, mod_byte_to_s, mod_byte_to_us);
     if (rval < 0) {
         modbus_free(mbctx);
         fatalx(EXIT_FAILURE, "modbus_set_byte_timeout: error(%s)", modbus_strerror(errno));
     }
+#elif (defined NUT_MODBUS_TIMEOUT_ARG_timeval_numeric_fields)
+    {   /* see comments above */
+        struct timeval to = (struct timeval){0};
+        to.tv_sec = mod_byte_to_s;
+        to.tv_usec = mod_byte_to_us;
+        /* void */ modbus_set_byte_timeout(mbctx, &to);
+    }
+/* #elif (defined NUT_MODBUS_TIMEOUT_ARG_timeval) // some un-castable type in fields */
+#endif /* NUT_MODBUS_TIMEOUT_ARG_* */
 }

--- a/m4/ax_c_pragmas.m4
+++ b/m4/ax_c_pragmas.m4
@@ -397,6 +397,33 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_SIGN_COMPARE_BESIDEFUNC], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wsign-compare" (outside functions)])
   ])
 
+  AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wsign-conversion"],
+    [ax_cv__pragma__gcc__diags_ignored_sign_conversion],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[void func(void) {
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+}
+]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_sign_conversion=yes],
+      [ax_cv__pragma__gcc__diags_ignored_sign_conversion=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_sign_conversion" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_SIGN_CONVERSION], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wsign-conversion"])
+  ])
+
+  AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wsign-conversion" (outside functions)],
+    [ax_cv__pragma__gcc__diags_ignored_sign_conversion_besidefunc],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wsign-conversion"]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_sign_conversion_besidefunc=yes],
+      [ax_cv__pragma__gcc__diags_ignored_sign_conversion_besidefunc=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_sign_conversion_besidefunc" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_SIGN_CONVERSION_BESIDEFUNC], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wsign-conversion" (outside functions)])
+  ])
+
   AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wunreachable-code-break"],
     [ax_cv__pragma__gcc__diags_ignored_unreachable_code_break],
     [AC_COMPILE_IFELSE(

--- a/m4/ax_c_pragmas.m4
+++ b/m4/ax_c_pragmas.m4
@@ -2,6 +2,9 @@ dnl Check for current compiler support of specific pragmas we use,
 dnl e.g. diagnostics management to keep warnings quiet sometimes
 
 AC_DEFUN([AX_C_PRAGMAS], [
+if test -z "${nut_have_ax_c_pragmas_seen}"; then
+  nut_have_ax_c_pragmas_seen="yes"
+
   CFLAGS_SAVED="${CFLAGS}"
   CXXFLAGS_SAVED="${CXXFLAGS}"
 
@@ -787,9 +790,13 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
 
   CFLAGS="${CFLAGS_SAVED}"
   CXXFLAGS="${CXXFLAGS_SAVED}"
+fi
 ])
 
 AC_DEFUN([AX_C_PRINTF_STRING_NULL], [
+if test -z "${nut_have_ax_c_printf_string_null_seen}"; then
+  nut_have_ax_c_printf_string_null_seen="yes"
+
   dnl ### To be sure, bolt the language
   AC_LANG_PUSH([C])
 
@@ -829,4 +836,5 @@ exit 0;
   ])
 
   AC_LANG_POP([C])
+fi
 ])

--- a/m4/nut_check_libmodbus.m4
+++ b/m4/nut_check_libmodbus.m4
@@ -84,14 +84,14 @@ if test -z "${nut_have_libmodbus_seen}"; then
 			[nut_cv_func_modbus_set_byte_timeout_args],
 			[nut_cv_func_modbus_set_byte_timeout_args="unknown"
 			 AC_COMPILE_IFELSE(
-				[dnl Try purely the new API (timeval)
+				[dnl Try purely the old API (timeval)
 				 AC_LANG_PROGRAM([
 #include <time.h>
 #include <modbus.h>
 ], [modbus_t *ctx; struct timeval to = (struct timeval){0};
 modbus_set_byte_timeout(ctx, &to);])
 				], [nut_cv_func_modbus_set_byte_timeout_args="timeval"],
-				[dnl Try another API variant: old API with
+				[dnl Try another API variant: new API with
 				 dnl fields of struct timeval as numbers
 				 dnl (checks they exist, and are compatible
 				 dnl numeric types so compiler can convert)
@@ -115,7 +115,7 @@ uint32_t to_sec = to.tv_sec, to_usec = to.tv_usec;
 modbus_set_byte_timeout(ctx, to_sec, to_usec);
 ])
 					], [nut_cv_func_modbus_set_byte_timeout_args="sec_usec_uint32_cast_timeval_fields"],
-					[dnl Try another API variant: old API purely
+					[dnl Try another API variant: new API purely (two uint32's)
 					 AC_COMPILE_IFELSE(
 						[AC_LANG_PROGRAM([
 #include <stdint.h>

--- a/m4/nut_check_libmodbus.m4
+++ b/m4/nut_check_libmodbus.m4
@@ -88,8 +88,8 @@ if test -z "${nut_have_libmodbus_seen}"; then
 				 AC_LANG_PROGRAM([
 #include <time.h>
 #include <modbus.h>
-], [modbus_t ctx = (modbus_t){0}; struct timeval to = (struct timeval){0};
-modbus_set_byte_timeout(&ctx, &to);])
+], [modbus_t *ctx; struct timeval to = (struct timeval){0};
+modbus_set_byte_timeout(ctx, &to);])
 				], [nut_cv_func_modbus_set_byte_timeout_args="timeval"],
 				[dnl Try another API variant: old API with
 				 dnl fields of struct timeval as numbers
@@ -100,7 +100,7 @@ modbus_set_byte_timeout(&ctx, &to);])
 #include <time.h>
 #include <stdint.h>
 #include <modbus.h>
-], [modbus_t ctx = (modbus_t){0}; struct timeval to = (struct timeval){0};
+], [modbus_t *ctx; struct timeval to = (struct timeval){0};
 /* TODO: Clarify and detect warning names and
  * so pragmas for signed/unsigned assignment (e.g.
  * for timeval definitions that have "long" fields)
@@ -112,7 +112,7 @@ modbus_set_byte_timeout(&ctx, &to);])
 # pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
 uint32_t to_sec = to.tv_sec, to_usec = to.tv_usec;
-modbus_set_byte_timeout(&ctx, to_sec, to_usec);
+modbus_set_byte_timeout(ctx, to_sec, to_usec);
 ])
 					], [nut_cv_func_modbus_set_byte_timeout_args="sec_usec_uint32_cast_timeval_fields"],
 					[dnl Try another API variant: old API purely
@@ -120,8 +120,8 @@ modbus_set_byte_timeout(&ctx, to_sec, to_usec);
 						[AC_LANG_PROGRAM([
 #include <stdint.h>
 #include <modbus.h>
-], [modbus_t ctx = (modbus_t){0}; uint32_t to_sec = 0, to_usec = 0;
-modbus_set_byte_timeout(&ctx, to_sec, to_usec);])
+], [modbus_t *ctx; uint32_t to_sec = 0, to_usec = 0;
+modbus_set_byte_timeout(ctx, to_sec, to_usec);])
 						], [nut_cv_func_modbus_set_byte_timeout_args="sec_usec_uint32"])
 					])
 				])

--- a/m4/nut_check_libmodbus.m4
+++ b/m4/nut_check_libmodbus.m4
@@ -69,6 +69,8 @@ if test -z "${nut_have_libmodbus_seen}"; then
 	AC_CHECK_HEADERS(modbus.h, [nut_have_libmodbus=yes], [nut_have_libmodbus=no], [AC_INCLUDES_DEFAULT])
 	AC_CHECK_FUNCS(modbus_new_rtu, [], [nut_have_libmodbus=no])
 	AC_CHECK_FUNCS(modbus_new_tcp, [], [nut_have_libmodbus=no])
+	AC_CHECK_FUNCS(modbus_set_byte_timeout, [], [nut_have_libmodbus=no])
+	AC_CHECK_FUNCS(modbus_set_response_timeout, [], [nut_have_libmodbus=no])
 
 	if test "${nut_have_libmodbus}" = "yes"; then
 		LIBMODBUS_CFLAGS="${CFLAGS}"

--- a/m4/nut_check_libmodbus.m4
+++ b/m4/nut_check_libmodbus.m4
@@ -159,16 +159,20 @@ modbus_set_byte_timeout(ctx, to_sec, to_usec);])
 		dnl it simple -- and assume some same approach
 		dnl applies to the same generation of the library.
 		 AC_LANG_POP([C])
-		 AS_IF([test x"$nut_cv_func_modbus_set_byte_timeout_args" = x"unknown"],
-			[AC_MSG_WARN([Cannot find proper types to use for modbus_set_byte_timeout])
-			 nut_have_libmodbus=no],
-			[AC_MSG_RESULT([Found types to use for modbus_set_byte_timeout: ${nut_cv_func_modbus_set_byte_timeout_args}])
-			 dnl NOTE: code should check for having a token name defined e.g.:
-			 dnl   #ifdef NUT_MODBUS_TIMEOUT_ARG_sec_usec_uint32
-			 AC_DEFINE_UNQUOTED(
-				[NUT_MODBUS_TIMEOUT_ARG_${nut_cv_func_modbus_set_byte_timeout_args}],
-				1, [Define to specify timeout method args approach for libmodbus])
-			])
+		 AC_MSG_RESULT([Found types to use for modbus_set_byte_timeout: ${nut_cv_func_modbus_set_byte_timeout_args}])
+		 dnl NOTE: code should check for having a token name defined e.g.:
+		 dnl   #ifdef NUT_MODBUS_TIMEOUT_ARG_sec_usec_uint32
+		 dnl Alas, we can't pass variables as macro name to AC_DEFINE
+		 COMMENT="Define to specify timeout method args approach for libmodbus"
+		 AS_CASE(["${nut_cv_func_modbus_set_byte_timeout_args}"],
+			[timeval_numeric_fields], [AC_DEFINE([NUT_MODBUS_TIMEOUT_ARG_timeval_numeric_fields], 1, [${COMMENT}])],
+			[timeval], [AC_DEFINE([NUT_MODBUS_TIMEOUT_ARG_timeval], 1, [${COMMENT}])],
+			[sec_usec_uint32_cast_timeval_fields], [AC_DEFINE([NUT_MODBUS_TIMEOUT_ARG_sec_usec_uint32_cast_timeval_fields], 1, [${COMMENT}])],
+			[sec_usec_uint32], [AC_DEFINE([NUT_MODBUS_TIMEOUT_ARG_sec_usec_uint32], 1, [${COMMENT}])],
+			[dnl default
+			 AC_MSG_WARN([Cannot find proper types to use for modbus_set_byte_timeout])
+			 nut_have_libmodbus=no]
+			)
 	])
 
 	AS_IF([test x"${nut_have_libmodbus}" = x"yes"],

--- a/m4/nut_check_libmodbus.m4
+++ b/m4/nut_check_libmodbus.m4
@@ -72,10 +72,10 @@ if test -z "${nut_have_libmodbus_seen}"; then
 	AC_CHECK_FUNCS(modbus_set_byte_timeout, [], [nut_have_libmodbus=no])
 	AC_CHECK_FUNCS(modbus_set_response_timeout, [], [nut_have_libmodbus=no])
 
-	if test "${nut_have_libmodbus}" = "yes"; then
-		LIBMODBUS_CFLAGS="${CFLAGS}"
-		LIBMODBUS_LIBS="${LIBS}"
-	fi
+	AS_IF([test x"${nut_have_libmodbus}" = x"yes"],
+		[LIBMODBUS_CFLAGS="${CFLAGS}"
+		 LIBMODBUS_LIBS="${LIBS}"]
+	)
 
 	dnl restore original CFLAGS and LIBS
 	CFLAGS="${CFLAGS_ORIG}"


### PR DESCRIPTION
As discussed in PR networkupstools/nut#1239 there are two libmodbus API variants to consider on the build farm reflecting current and "recent" distros for NUT:
* 3.0.x has methods taking `struct timeval` and no return (void), e.g.: https://libmodbus.org/docs/v3.0.8/modbus_set_response_timeout.html
* 3.1.x has same-named methods taking two numbers for sec/usec timeout parts and returning an error instantly, e.g.: https://github.com/stephane/libmodbus/blob/master/doc/modbus_set_response_timeout.txt

In both cases, error-check should happen at usage time and was not specifically investigated for handled in this PR. Per docs,
> When a byte timeout is set, if elapsed time for the first byte of response is longer than the given timeout, an `ETIMEDOUT` error will be raised by the function waiting for a response